### PR TITLE
Update analysis rules

### DIFF
--- a/lib/analysis_options.0.0.1.yaml
+++ b/lib/analysis_options.0.0.1.yaml
@@ -114,9 +114,9 @@ dart_code_metrics:
         widgets-order:
           - constructor
           - init-state-method
-          - build-method
           - did-change-dependencies-method
           - did-update-widget-method
+          - build-method
           - dispose-method
     - newline-before-return
     - no-boolean-literal-compare

--- a/lib/analysis_options.0.0.1.yaml
+++ b/lib/analysis_options.0.0.1.yaml
@@ -9,35 +9,102 @@ analyzer:
 
 linter:
   rules:
+    - always_declare_return_types
+    - always_require_non_null_named_parameters
+    - annotate_overrides
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_single_cascade_in_expression_statements
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - empty_constructor_bodies
+    - library_names
+    - library_prefixes
+    - no_duplicate_case_values
+    - null_closures
+    - omit_local_variable_types
+    - prefer_adjacent_string_concatenation
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_final_fields
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_generic_function_type_aliases
+    - prefer_if_null_operators
+    - prefer_inlined_adds
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_getters_setters
+    - unnecessary_new
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - unsafe_html
+    - use_function_type_syntax_for_parameters
+    - use_rethrow_when_possible
+    - valid_regexps
     - require_trailing_commas
-    - use_build_context_synchronously
 
 dart_code_metrics:
   metrics:
     cyclomatic-complexity: 20
     number-of-parameters: 4
-    maximum-nesting-level: 1
+    maximum-nesting-level: 3
   metrics-exclude:
     - test/**
   rules:
-    - arguments-ordering:
-        child-last: true
+
+    # Common
+    - avoid-banned-imports:
+        entries:
+        - paths: ["data/", "domain/"]
+          deny: ["package:flutter/widgets.dart", "package:flutter/material.dart", "package:flutter/cupertino.dart"]
+          message: "Do not import UI libs in domain/data layers"
+    - avoid-cascade-after-if-null
+    - avoid-collection-methods-with-unrelated-types
+    - avoid-double-slash-imports
+    - avoid-duplicate-exports
+    - avoid-dynamic
+    - avoid-global-state
+    - avoid-ignoring-return-values
+    - avoid-missing-enum-constant-in-map
     - avoid-nested-conditional-expressions:
         acceptable-level: 2
-    - prefer-moving-to-variable:
-        allowed-duplicated-chains: 2
-    - prefer-match-file-name:
-        exclude:
-          - test/**
-    - no-equal-arguments:
-        ignored-parameters:
-          - height
-          - width
+    - avoid-non-null-assertion
+    - avoid-passing-async-when-sync-expected
+    - avoid-redundant-async
+    - avoid-throw-in-catch-block
+    - avoid-unnecessary-conditionals
+    - avoid-unnecessary-type-assertions
+    - avoid-unnecessary-type-casts
+    - avoid-unrelated-type-assertions
+    - avoid-unused-parameters
     - ban-name:
         entries:
           - ident: DateTime.now
             description: Please use TimeProvider.now() instead
+    - binary-expression-operand-order
+    - double-literal-format
+    - format-comment:
+        only-doc-comments: false
     - member-ordering:
+        alphabetize: false
         order:
           - public-fields
           - private-fields
@@ -51,48 +118,35 @@ dart_code_metrics:
           - did-change-dependencies-method
           - did-update-widget-method
           - dispose-method
-    - avoid-cascade-after-if-null
-    - avoid-collection-methods-with-unrelated-types
-    - avoid-duplicate-exports
-    - avoid-dynamic
-    - avoid-global-state
-    - avoid-ignoring-return-values
-    - avoid-missing-enum-constant-in-map
-    - avoid-non-null-assertion
-    - avoid-passing-async-when-sync-expected
-    - avoid-redundant-async
-    - avoid-throw-in-catch-block
-    - avoid-unnecessary-type-assertions
-    - avoid-unnecessary-type-casts
-    - avoid-unrelated-type-assertions
-    - avoid-unused-parameters
-    - binary-expression-operand-order
-    - double-literal-format
+    - newline-before-return
     - no-boolean-literal-compare
     - no-empty-block
+    - no-equal-arguments:
+        ignored-parameters:
+          - height
+          - width
     - no-equal-then-else
-    - no-magic-number
-    #allowed: [3.14, 100, 12]
     - no-object-declaration
     - prefer-async-await
     - prefer-commenting-analyzer-ignores
     - prefer-conditional-expressions
     - prefer-correct-test-file-name
-    - prefer-correct-type-name
+    - prefer-correct-type-name:
+        min-length: 3
     - prefer-enums-by-name
     - prefer-first
     - prefer-immediate-return
     - prefer-iterable-of
     - prefer-last
-    #- prefer-static-class
-    #  ignore-annotations:
-    #    - allowedAnnotation
-    #  ignore-private: true
-    #  ignore-names:
-    #    - (.*)Provider
-    #    - use(.*)
-    - avoid-expanded-as-spacer
+    - prefer-match-file-name:
+        exclude:
+          - test/**   
+    - prefer-moving-to-variable:
+        allowed-duplicated-chains: 2
+
+    # Flutter
     - always-remove-listener
+    - avoid-expanded-as-spacer
     - avoid-returning-widgets
     - avoid-shrink-wrap-in-lists
     - avoid-unnecessary-setstate
@@ -104,6 +158,8 @@ dart_code_metrics:
     - prefer-extracting-callbacks
     - prefer-single-widget-per-file:
         ignore-private-widgets: true
+    - prefer-using-list-view
+
   anti-patterns:
     - long-method
     - long-parameter-list


### PR DESCRIPTION
- removed use_build_context_synchronously since it is included in flutter_lints
- added rules that we use in all project to linter 
- bumped nesting level to 3 since 1 is too small 
- reordered dart_code_metrics as in source so it will be easier to navigate
- removed arguments-ordering since it shows warning on widgets like MaterialApp that wants routes to be on top
- added format-comment - nothing much to configure - can only add excludes that I think not needed
- added avoid-double-slash-imports
- added avoid-unnecessary-conditionals
- removed no-magic-number
- added prefer-correct-type-name
- removed commented prefer-static-class - we use this for mock object for testing and also for some global methods in our apps. Instead of writing a lot of ignoring rules code reviewer will detect if this is unacceptable
- added prefer-using-list-view